### PR TITLE
feat: add sepolia testnet

### DIFF
--- a/templates/nodejs/ethers5/README.md
+++ b/templates/nodejs/ethers5/README.md
@@ -12,7 +12,7 @@ This is a [zkSync](https://zksync.io) + [ethers v5](https://docs.ethers.org/v5/)
 
 # Configuration
 
-By default your code will be run against zkSync Era Testnet. If you wish to use a different network, you can change the `defaultChain` in `src/utils/chains.ts` file.
+By default your code will be run against zkSync Sepolia Testnet. If you wish to use a different network, you can change the `defaultChain` in `src/utils/chains.ts` file.
 
 Alternatively, you can use `getProvider` or `getWallet` with a custom `chain` parameter.
 

--- a/templates/nodejs/ethers5/src/main.ts
+++ b/templates/nodejs/ethers5/src/main.ts
@@ -6,7 +6,7 @@
 
 // === CONFIG ===
 
-// By default zkSync Testnet will be used (e.g. when calling getWallet() or getProvider())
+// By default zkSync Sepolia Testnet will be used (e.g. when calling getWallet() or getProvider())
 // Customize default network in utils/chains.ts `defaultChain`
 
 

--- a/templates/nodejs/ethers5/src/utils/chains.ts
+++ b/templates/nodejs/ethers5/src/utils/chains.ts
@@ -15,9 +15,15 @@ export const ethereumMainnet: L1Chain = {
   rpcUrl: "https://rpc.ankr.com/eth",
   blockExplorerUrl: "https://etherscan.io",
 }
+export const ethereumSepolia: L1Chain = {
+  id: 11155111,
+  name: "Ethereum Sepolia Testnet",
+  rpcUrl: "https://rpc.ankr.com/eth_sepolia",
+  blockExplorerUrl: "https://sepolia.etherscan.io",
+}
 export const ethereumGoerli: L1Chain = {
   id: 5,
-  name: "Ethereum Goerli",
+  name: "Ethereum Goerli Testnet",
   rpcUrl: "https://rpc.ankr.com/eth_goerli",
   blockExplorerUrl: "https://goerli.etherscan.io",
 }
@@ -29,18 +35,25 @@ export const ethereumDockerizedNode: L1Chain = {
 
 export const zkSyncMainnet: Chain = {
   id: 324,
-  name: "zkSync Era",
+  name: "zkSync",
   rpcUrl: "https://mainnet.era.zksync.io",
   blockExplorerUrl: "https://explorer.zksync.io",
   blockExplorerApi: "https://block-explorer-api.mainnet.zksync.io", // Docs: https://block-explorer-api.mainnet.zksync.io/docs
   l1: ethereumMainnet,
 }
-export const zkSyncTestnet: Chain = {
+export const zkSyncSepoliaTestnet: Chain = {
+  id: 300,
+  name: "zkSync Sepolia Testnet",
+  rpcUrl: "https://sepolia.era.zksync.dev",
+  blockExplorerUrl: "https://sepolia.explorer.zksync.io",
+  blockExplorerApi: "https://block-explorer-api.sepolia.zksync.dev", // Docs: https://block-explorer-api.sepolia.zksync.dev/docs
+}
+export const zkSyncGoerliTestnet: Chain = { // deprecated network
   id: 280,
-  name: "zkSync Era Testnet",
+  name: "zkSync Goerli Testnet",
   rpcUrl: "https://testnet.era.zksync.dev",
   blockExplorerUrl: "https://goerli.explorer.zksync.io",
-  blockExplorerApi: "https://block-explorer-api.testnets.zksync.dev", // Docs: https://block-explorer-api.testnets.zksync.dev
+  blockExplorerApi: "https://block-explorer-api.testnets.zksync.dev", // Docs: https://block-explorer-api.testnets.zksync.dev/docs
 }
 
 export const zkSyncDockerizedNode: Chain = {
@@ -62,9 +75,10 @@ export const zkSyncInMemoryNode: Chain = {
 
 export const chains: Chain[] = [
   zkSyncMainnet,
-  zkSyncTestnet,
+  zkSyncSepoliaTestnet,
+  zkSyncGoerliTestnet,
   zkSyncDockerizedNode,
   zkSyncInMemoryNode
 ]
 
-export const defaultChain = zkSyncTestnet;
+export const defaultChain = zkSyncSepoliaTestnet;

--- a/templates/nodejs/viem/README.md
+++ b/templates/nodejs/viem/README.md
@@ -12,7 +12,7 @@ This is a [zkSync](https://zksync.io) + [viem](https://viem.sh) + [Node.js](http
 
 # Configuration
 
-By default your code will be run against zkSync Era Testnet. If you wish to use a different network, you can change the `defaultChain` in `src/utils/chains.ts` file.
+By default your code will be run against zkSync Sepolia Testnet. If you wish to use a different network, you can change the `defaultChain` in `src/utils/chains.ts` file.
 
 Alternatively, you can use `getPublicClient` or `getWalletClient` with a custom `chain` parameter.
 

--- a/templates/nodejs/viem/src/main.ts
+++ b/templates/nodejs/viem/src/main.ts
@@ -4,7 +4,7 @@
 
 // === CONFIG ===
 
-// By default zkSync Testnet will be used (e.g. when calling getPublicClient() or getWalletClient())
+// By default zkSync Sepolia Testnet will be used (e.g. when calling getPublicClient() or getWalletClient())
 // Customize default network in utils/chains.ts `defaultChain`
 
 

--- a/templates/nodejs/viem/src/utils/chains.ts
+++ b/templates/nodejs/viem/src/utils/chains.ts
@@ -1,5 +1,30 @@
-import { type Chain, zkSync, zkSyncTestnet } from "viem/chains";
+import {
+  type Chain,
+  zkSync,
+  zkSyncTestnet as zkSyncGoerliTestnet // deprecated network
+} from "viem/chains";
 
+export const zkSyncSepoliaTestnet = {
+  id: 300,
+  name: "zkSync Sepolia Testnet",
+  network: "zksync-sepolia-testnet",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ["https://sepolia.era.zksync.dev"],
+    },
+    public: {
+      http: ["https://sepolia.era.zksync.dev"],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: "Block Explorer",
+      url: "https://sepolia.explorer.zksync.io",
+    },
+  },
+  testnet: true
+}
 export const zkSyncDockerizedNode = {
   id: 270,
   name: "Dockerized local node",
@@ -39,9 +64,10 @@ export const zkSyncInMemoryNode = {
 
 export const chains: Chain[] = [
   zkSync,
-  zkSyncTestnet,
+  zkSyncSepoliaTestnet,
+  zkSyncGoerliTestnet,
   zkSyncDockerizedNode,
   zkSyncInMemoryNode,
 ]
 
-export const defaultChain = zkSyncTestnet;
+export const defaultChain = zkSyncSepoliaTestnet;


### PR DESCRIPTION
# What :computer: 
* Add zkSync Sepolia Testnet, make it default network

# Why :hand:
* Since zkSync Goerli Testnet is being deprecated

# Evidence :camera:
N/A